### PR TITLE
Add ability to step back+forward and reset history in visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ use of GUAC, we recommend using the
 
 To get started with GUAC visualizer, look at our guide [here](docs/setup.md).
 
+Once started, looking through packages might look something like this:
+
+<img src="https://github.com/guacsec/guac-visualizer/assets/68356865/9835362c-8138-44aa-b94f-fea7c5a99327" height="400" width="500">
 
 ## Looking for GUAC?
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -121,7 +121,6 @@ export default function Home() {
     setCurrentNode(newNode);
     setBackStack(newBackStack);
 
-    // Fetch new data and display it
     DataFetcher(newNode.id).then((res) => {
       const graphData = { nodes: [], links: [] };
       res.forEach((n) => {
@@ -141,7 +140,6 @@ export default function Home() {
     setCurrentNode(newNode);
     setForwardStack(newForwardStack);
 
-    // Fetch new data and display it
     DataFetcher(newNode.id).then((res) => {
       const graphData = { nodes: [], links: [] };
       res.forEach((n) => {
@@ -278,7 +276,6 @@ export default function Home() {
               linkDirectionalArrowLength={3}
               linkDirectionalArrowRelPos={3}
               linkDirectionalParticles={0}
-              // dataFetcher={localDataFetcher}
               onNodeDragEnd={(node) => {
                 node.fx = node.x;
                 node.fy = node.y;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -250,7 +250,7 @@ export default function Home() {
               <button
                 type="button"
                 className="text-xl rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white shadow-sm"
-                title="Go back to the previous node"
+                title="Go back to previous visualization"
                 onClick={handleBackClick}
               >
                 Back
@@ -258,7 +258,7 @@ export default function Home() {
               <button
                 type="button"
                 className="text-xl rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white shadow-sm"
-                title="Go forward to the next node"
+                title="Go forward to next visualization"
                 onClick={handleForwardClick}
               >
                 Forward

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -292,7 +292,7 @@ export default function Home() {
               </button>
             </div>
           </div>
-          <div className="w-1/2 flex flex-wrap justify-between lg:justify-center">
+          <div className="lg:col-span-2">
             <ForceGraph2D
               onNodeClick={(node) => handleNodeClick(node)}
               graphData={graphData}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,9 +40,29 @@ export default function Home() {
   const [highlightSbom, setHighlightSbom] = useState(false);
   const [highlightBuilder, setHighlightBuilder] = useState(false);
 
+  const [firstNode, setFirstNode] = useState(null);
   const [backStack, setBackStack] = useState([]);
   const [forwardStack, setForwardStack] = useState([]);
   const [currentNode, setCurrentNode] = useState(null);
+
+  const [initialGraphData, setInitialGraphData] = useState(null);
+
+  const setGraphDataWithInitial = (data) => {
+    setGraphData(data);
+    if (!initialGraphData) {
+      setInitialGraphData(data);
+    }
+  };
+
+  // create the reset function
+  const reset = () => {
+    if (initialGraphData) {
+      setGraphData(initialGraphData);
+      setBackStack([]);
+      setForwardStack([]);
+      setCurrentNode(null);
+    }
+  };
 
   // this is for the visual graph
   const [graphData, setGraphData] = useState({ nodes: [], links: [] });
@@ -52,10 +72,6 @@ export default function Home() {
   const packageError = packageTypesQuery.error;
 
   const router = useRouter();
-
-  useEffect(() => {
-    console.log(graphData.nodes);
-  }, [graphData]);
 
   const handleArtifactClick = () => {
     setHighlightArtifact(!highlightArtifact);
@@ -72,7 +88,6 @@ export default function Home() {
   const handleBuilderClick = () => {
     setHighlightBuilder(!highlightBuilder);
   };
-  // ...
 
   const resetType = () => {
     setPackageNamespaces(initialPackageNamespaces);
@@ -98,7 +113,7 @@ export default function Home() {
       res.forEach((n) => {
         ParseAndFilterGraph(graphData, ParseNode(n));
       });
-      setGraphData(graphData);
+      setGraphDataWithInitial(graphData);
     });
   };
 
@@ -109,6 +124,9 @@ export default function Home() {
     if (currentNode) {
       setBackStack((prevBackStack) => [...prevBackStack, currentNode]);
       setForwardStack([]);
+    }
+    if (!firstNode) {
+      setFirstNode(node);
     }
     setCurrentNode(node);
     fetchAndSetGraphData(node.id);
@@ -161,7 +179,7 @@ export default function Home() {
       nodeIds.forEach((nodeId) => {
         GetNodeById(nodeId).then((res) => {
           ParseAndFilterGraph(graphData, ParseNode(res.node));
-          setGraphData(graphData);
+          setGraphDataWithInitial(graphData);
         });
       });
       setRenderedInitialGraph(true);
@@ -217,7 +235,7 @@ export default function Home() {
               packageNamespace={packageNamespace}
               packageName={packageName}
               setPackageVersionFunc={setPackageVersion}
-              setGraphDataFunc={setGraphData}
+              setGraphDataFunc={setGraphDataWithInitial}
             />
           </div>
         </div>
@@ -262,6 +280,14 @@ export default function Home() {
                 onClick={handleForwardClick}
               >
                 Forward
+              </button>
+              <button
+                type="button"
+                className="text-xl rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white shadow-sm"
+                title="Reset visualization"
+                onClick={reset}
+              >
+                Reset
               </button>
             </div>
           </div>
@@ -350,7 +376,6 @@ export default function Home() {
                     ctx.arc(node.x, node.y, shapeSize / 2, 0, 2 * Math.PI);
                     ctx.stroke();
                     ctx.fill();
-                    console.log("Testing if artifact is getting populated");
                     break;
                   default:
                     ctx.fillStyle = applyRedFillAndOutline ? "red" : "blue";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -241,8 +241,9 @@ export default function Home() {
         </div>
         <div className="grid grid-cols-3">
           <div className="w-full items-left justify-left font-mono text-sm p-24 lg:col-span-1">
-            <h2 className="my-5">Highlight Nodes</h2>
-            <div className="flex flex-col">
+            <h2 className="my-5 text-2xl">Highlight Nodes</h2>
+            <p className="py-2">Tip: Use click and scroll to adjust graph</p>
+            <div className="flex flex-col p-3">
               <Toggle
                 label="Artifacts"
                 toggled={highlightArtifact}
@@ -291,7 +292,7 @@ export default function Home() {
               </button>
             </div>
           </div>
-          <div className="lg:col-span-2">
+          <div className="w-1/2 flex flex-wrap justify-between lg:justify-center">
             <ForceGraph2D
               onNodeClick={(node) => handleNodeClick(node)}
               graphData={graphData}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,7 +40,6 @@ export default function Home() {
   const [highlightSbom, setHighlightSbom] = useState(false);
   const [highlightBuilder, setHighlightBuilder] = useState(false);
 
-  // NODE HISTORY
   const [backStack, setBackStack] = useState([]);
   const [forwardStack, setForwardStack] = useState([]);
   const [currentNode, setCurrentNode] = useState(null);
@@ -92,17 +91,9 @@ export default function Home() {
     setPackageVersion("");
   };
 
-  // NODE HISTORY
-  const handleNodeClick = (node) => {
-    if (currentNode) {
-      setBackStack((prevBackStack) => [...prevBackStack, currentNode]);
-      // Clear the forward stack when a new node is clicked
-      setForwardStack([]);
-    }
-    setCurrentNode(node);
-
-    // Fetch new data and expand the node
-    DataFetcher(node.id).then((res) => {
+  // helper function to fetch data related to the node and update the graph
+  const fetchAndSetGraphData = (nodeId) => {
+    DataFetcher(nodeId).then((res) => {
       const graphData = { nodes: [], links: [] };
       res.forEach((n) => {
         ParseAndFilterGraph(graphData, ParseNode(n));
@@ -111,6 +102,21 @@ export default function Home() {
     });
   };
 
+  // handler for node click events
+  // if a current node exists, add it to the back stack
+  // clear the forward stack when a new node is clicked
+  const handleNodeClick = (node) => {
+    if (currentNode) {
+      setBackStack((prevBackStack) => [...prevBackStack, currentNode]);
+      setForwardStack([]);
+    }
+    setCurrentNode(node);
+    fetchAndSetGraphData(node.id);
+  };
+
+  // handler for the 'Back' button click event
+  // updates the back and forward stacks, sets the previous node as the current node,
+  // and fetches and sets data for the new current node
   const handleBackClick = () => {
     if (backStack.length === 0) return;
 
@@ -121,15 +127,12 @@ export default function Home() {
     setCurrentNode(newNode);
     setBackStack(newBackStack);
 
-    DataFetcher(newNode.id).then((res) => {
-      const graphData = { nodes: [], links: [] };
-      res.forEach((n) => {
-        ParseAndFilterGraph(graphData, ParseNode(n));
-      });
-      setGraphData(graphData);
-    });
+    fetchAndSetGraphData(newNode.id);
   };
 
+  // handler for the 'Forward' button click event
+  // updates the back and forward stacks, sets the next node as the current node,
+  // and fetches and sets data for the new current node
   const handleForwardClick = () => {
     if (forwardStack.length === 0) return;
 
@@ -140,13 +143,7 @@ export default function Home() {
     setCurrentNode(newNode);
     setForwardStack(newForwardStack);
 
-    DataFetcher(newNode.id).then((res) => {
-      const graphData = { nodes: [], links: [] };
-      res.forEach((n) => {
-        ParseAndFilterGraph(graphData, ParseNode(n));
-      });
-      setGraphData(graphData);
-    });
+    fetchAndSetGraphData(newNode.id);
   };
 
   if (!packageError && !packageLoading) {


### PR DESCRIPTION
Addresses issue https://github.com/guacsec/guac-visualizer/issues/17

Adds three buttons for going back and forward history with visualizations, as well as a reset option.


<img src="https://github.com/guacsec/guac-visualizer/assets/68356865/9835362c-8138-44aa-b94f-fea7c5a99327" height="400" width="500">