### PR TITLE
Breadcrumb navigation enhancements and graph interactions

### DIFF
--- a/app/ForceGraph2D.tsx
+++ b/app/ForceGraph2D.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ForceGraph, {
   LinkObject,
   ForceGraphMethods,
@@ -73,11 +73,21 @@ const ForceGraph2D: React.FC<ForceGraph2DWrapperProps & ResponsiveProps> = ({
 
   const fgRef = useRef<ForceGraphMethods>();
 
+  const centerGraph = () => {
+    if (fgRef.current && width > 0 && height > 0) {
+      fgRef.current.centerAt(width / 20, height / 10, 400);
+    }
+  };
+
+  useEffect(() => {
+    centerGraph();
+  }, [graphData, width, height]);
+
   const handleClick = useCallback(
     (node: NodeObject) => {
       dataFetcher(node.id);
     },
-    [fgRef, dataFetcher]
+    [dataFetcher]
   );
 
   if (selectedNode) {
@@ -205,7 +215,7 @@ const ForceGraph2D: React.FC<ForceGraph2DWrapperProps & ResponsiveProps> = ({
         linkLabel={linkLabel}
         nodeId="id"
         linkDirectionalParticles={linkDirectionalParticles}
-        linkDirectionalParticleWidth={0.5}
+        linkDirectionalParticleWidth={10.5}
         linkSource={linkSource}
         linkTarget={linkTarget}
         linkWidth={1}

--- a/components/breadcrumbs.tsx
+++ b/components/breadcrumbs.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { ChevronDoubleRightIcon } from "@heroicons/react/24/solid";
-
 interface BreadcrumbProps {
   breadcrumb: string[];
   handleNodeClick: (nodeIndex: number) => void;
+  currentIndex: number;
 }
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   breadcrumb,
   handleNodeClick,
+  currentIndex,
 }) => {
   if (breadcrumb.length === 0) {
     return null;
@@ -18,7 +19,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
     <nav className="flex" aria-label="Breadcrumb">
       <ol
         role="list"
-        className="flex flex-wrap space-x-4 rounded-xl bg-white mt-10 px-6 py-2 shadow"
+        className="flex flex-wrap space-x-4 rounded-xl bg-white mt-10 px-6 shadow"
       >
         {breadcrumb.map((label, index) => {
           const maxLabelLength = 15;
@@ -30,22 +31,22 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
 
           return (
             <li className="flex" key={index}>
+              {index !== 0 && (
+                <ChevronDoubleRightIcon
+                  className="w-5"
+                  style={{ color: "rgba(90, 75, 60, 0.3)" }}
+                />
+              )}
               <button
                 onClick={() => handleNodeClick(index)}
-                className="flex items-center"
+                className={`flex items-center ${
+                  index === currentIndex
+                    ? "bg-gray-300 font-bold text-black p-1 m-2"
+                    : ""
+                }`}
               >
-                {" "}
-                {/* Added button */}
-                {index !== 0 && (
-                  <ChevronDoubleRightIcon
-                    className="w-8"
-                    style={{ color: "rgba(90, 75, 60, 0.3)" }}
-                  />
-                )}
                 <div className="text-gray-500">
-                  <span className="ml-2 text-sm font-medium">
-                    {truncatedLabel}
-                  </span>
+                  <span className="text-sm font-medium">{truncatedLabel}</span>
                 </div>
               </button>
             </li>

--- a/components/breadcrumbs.tsx
+++ b/components/breadcrumbs.tsx
@@ -6,7 +6,10 @@ interface BreadcrumbProps {
   handleNodeClick: (nodeIndex: number) => void;
 }
 
-export const Breadcrumb: React.FC<BreadcrumbProps> = ({ breadcrumb }) => {
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({
+  breadcrumb,
+  handleNodeClick,
+}) => {
   if (breadcrumb.length === 0) {
     return null;
   }
@@ -27,7 +30,12 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ breadcrumb }) => {
 
           return (
             <li className="flex" key={index}>
-              <div className="flex items-center">
+              <button
+                onClick={() => handleNodeClick(index)}
+                className="flex items-center"
+              >
+                {" "}
+                {/* Added button */}
                 {index !== 0 && (
                   <ChevronDoubleRightIcon
                     className="w-8"
@@ -39,7 +47,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ breadcrumb }) => {
                     {truncatedLabel}
                   </span>
                 </div>
-              </div>
+              </button>
             </li>
           );
         })}

--- a/components/navigationButtons.tsx
+++ b/components/navigationButtons.tsx
@@ -7,6 +7,7 @@ interface NavigationButtonsProps {
   handleBackClick: () => void;
   handleForwardClick: () => void;
   reset: () => void;
+  userInteractedWithPath: boolean;
 }
 
 export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
@@ -16,6 +17,7 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
   handleBackClick,
   handleForwardClick,
   reset,
+  userInteractedWithPath,
 }) => {
   return (
     <div className="py-10 my-5 flex space-x-3">
@@ -28,7 +30,7 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
         }`}
         title="Go back to previous visualization"
         onClick={handleBackClick}
-        disabled={backStack.length === 0}
+        disabled={!userInteractedWithPath || backStack.length === 0}
       >
         Back
       </button>
@@ -42,7 +44,9 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
         title="Go forward to next visualization"
         onClick={handleForwardClick}
         disabled={
-          breadcrumb.length === 0 || currentIndex >= breadcrumb.length - 1
+          !userInteractedWithPath ||
+          breadcrumb.length === 0 ||
+          currentIndex >= breadcrumb.length - 1
         }
       >
         Forward

--- a/components/navigationButtons.tsx
+++ b/components/navigationButtons.tsx
@@ -1,10 +1,9 @@
-// NavigationButtons.tsx
 import React from "react";
 
 interface NavigationButtonsProps {
   backStack: any[];
-  forwardStack: any[];
   breadcrumb: any[];
+  currentIndex: number;
   handleBackClick: () => void;
   handleForwardClick: () => void;
   reset: () => void;
@@ -12,8 +11,8 @@ interface NavigationButtonsProps {
 
 export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
   backStack,
-  forwardStack,
   breadcrumb,
+  currentIndex,
   handleBackClick,
   handleForwardClick,
   reset,
@@ -36,13 +35,15 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
       <button
         type="button"
         className={`rounded px-3 py-2 text-xs font-semibold shadow-sm ${
-          forwardStack.length === 0
+          breadcrumb.length === 0 || currentIndex >= breadcrumb.length - 1
             ? "bg-gray-300 dark:bg-slate-700 cursor-not-allowed"
             : "bg-slate-700 text-white"
         }`}
         title="Go forward to next visualization"
         onClick={handleForwardClick}
-        disabled={forwardStack.length === 0}
+        disabled={
+          breadcrumb.length === 0 || currentIndex >= breadcrumb.length - 1
+        }
       >
         Forward
       </button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useQuery } from "@apollo/client";
 import client from "@/apollo/client";
 import {
-  NeighborsDocument,
   NeighborsQuery,
   PackageTypesDocument,
-  PackageTypesQuery,
 } from "@/gql/__generated__/graphql";
 import { fetchNeighbors, parseAndFilterGraph } from "@/app/graph_queries";
 import { ParseNode } from "@/app/ggraph";
@@ -270,6 +267,7 @@ export default function Home() {
         <Breadcrumb
           breadcrumb={breadcrumb.map((item) => item.label)}
           handleNodeClick={handleBreadcrumbClick}
+          currentIndex={currentIndex}
         />
         <div className="mt-8 grid grid-cols-none grid-rows-4 lg:grid-rows-none lg:grid-cols-4 h-full w-full gap-8 lg:gap-4">
           <div className="flex flex-col font-mono text-sm p-4 row-span-1 lg:col-span-1">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -230,6 +230,8 @@ export default function Home() {
     setCurrentIndex(currentIndex - 1);
     setForwardStack(newForwardStack);
     setBackStack(newBackStack);
+
+    fetchAndSetGraphData(lastNode.id);
   };
 
   const handleForwardClick = () => {
@@ -244,6 +246,8 @@ export default function Home() {
     setCurrentIndex(currentIndex + 1);
     setBackStack(newBackStack);
     setForwardStack(newForwardStack);
+
+    fetchAndSetGraphData(nextNode.id);
   };
 
   return (

--- a/utils/graphDataHelpers.tsx
+++ b/utils/graphDataHelpers.tsx
@@ -1,8 +1,11 @@
+import { ParseNode } from "@/app/ggraph";
 import { GetNodeById, parseAndFilterGraph } from "@/app/graph_queries";
 import { GraphDataWithMetadata } from "@/components/graph/types";
 
 export const fetchAndParseNodes = (nodeIds: string[]) =>
-  Promise.all(nodeIds.map((nodeId) => GetNodeById(nodeId)));
+  Promise.all(nodeIds.map((nodeId) => GetNodeById(nodeId))).then((nodes) =>
+    nodes.map((node) => ParseNode(node.node))
+  );
 
 export const generateGraphDataFromNodes = (parsedNodes: any[]) => {
   let graphData: GraphDataWithMetadata = { nodes: [], links: [] };


### PR DESCRIPTION
- **Clickable Breadcrumb Labels:** breadcrumb labels are now clickable, which means users can now navigate to whichever breadcrumb state they were in.

- **Highlighting Current Breadcrumb State:** The current state in the breadcrumb is highlighted, so users can be aware where they are in the navigation.

- **Fixing Navigation Button Issue with Custom node ID urls:** Previously the logic assumed a user started out just using the package selector to generate a graph on the canvas.  This didn't, however, account for the fact that custom/generated urls (e.g., http://localhost:3000/?path=1,2,3,4,5) wouldn't work with the navigation system in place. Now that issue is resolved.

- **Centering on Graph Node:** Previously, there was an issue on how the graph loaded far away from the canvas's viewport. Now, there is added functionality to center the graph on specific nodes, improving the visual alignment and user focus.

- **Deleted Unused Code:** removed dead code.

<hr>

<img src="https://github.com/guacsec/guac-visualizer/assets/68356865/f3395666-556d-431c-a598-4d149c89a585" height="360px" width="auto" />