### PR TITLE
Fix vulnerability query text color in dark theme

### DIFF
--- a/components/queryvuln/queryVuln.tsx
+++ b/components/queryvuln/queryVuln.tsx
@@ -53,7 +53,7 @@ const QueryCertifyVuln: React.FC = () => {
     <div className="container mx-auto p-4">
       <h1 className="py-3 text-lg font-semibold">Query vulnerability</h1>
       <input
-        className="border rounded p-2 mb-4"
+        className="border rounded p-2 mb-4 dark:text-black"
         value={vulnerabilityID}
         onChange={(e) => setVulnerabilityID(e.target.value)}
         placeholder="Enter vuln ID here..."


### PR DESCRIPTION
The text color in the input field is white in the dark theme making it unreadable. This change makes the text remain black in the dark theme.