### PR TITLE
reduce docker container image size from 1.69GB to 1.07GB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       digest: ${{ steps.build_image.outputs.IMAGE_DIGEST }}
     env:
       IMAGE_URI: ghcr.io/${{ github.repository }}
-      BUILDER: paketobuildpacks/builder-jammy-full
+      BUILDER: paketobuildpacks/builder-jammy-base
       BUILDPACK: paketo-buildpacks/nodejs
     steps:
       - name: Checkout code
@@ -47,7 +47,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup pack 
+      - name: Setup pack
         uses: buildpacks/github-actions/setup-pack@7fc3d673350db0fff960cc94a3b9b80e5b663ae2 # v5.0.0
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.6.0 # main
@@ -56,7 +56,7 @@ jobs:
       - name: Install crane
         uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # v0.1
       - name: Build image
-        id: build_image 
+        id: build_image
         run: |
           #!/usr/bin/env bash
           set -euo pipefail

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       digest: ${{ steps.build_n_publish_image.outputs.IMAGE_DIGEST }}
     env:
       IMAGE_URI: ghcr.io/${{ github.repository }}
-      BUILDER: paketobuildpacks/builder-jammy-full
+      BUILDER: paketobuildpacks/builder-jammy-base
       BUILDPACK: paketo-buildpacks/nodejs
       BUILDPACK_SBOM_OUTPUT_DIR: sbom-output-dir
       BUILDPACK_SPDX_SBOM: "launch/paketo-buildpacks_yarn-install/launch-modules/sbom.spdx.json"
@@ -46,7 +46,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup pack 
+      - name: Setup pack
         uses: buildpacks/github-actions/setup-pack@7fc3d673350db0fff960cc94a3b9b80e5b663ae2 # v5.0.0
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.6.0 # main
@@ -58,9 +58,9 @@ jobs:
         run: |
           #!/usr/bin/env bash
           set -euo pipefail
-          npm version --no-git-tag-version $(git describe --tags --abbrev=0)          
+          npm version --no-git-tag-version $(git describe --tags --abbrev=0)
       - name: Build and publish image
-        id: build_n_publish_image 
+        id: build_n_publish_image
         run: |
           #!/usr/bin/env bash
           set -euo pipefail

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "node": "20.*.*"
+  },
   "name": "guac-visualizer",
   "version": "main",
   "private": true,
@@ -17,7 +20,7 @@
     "@floating-ui/dom": "^1.2.6",
     "@heroicons/react": "^2.0.18",
     "@textea/json-viewer": "^2.14.1",
-    "@types/node": "18.11.18",
+    "@types/node": "^20.14.8",
     "@types/react": "18.0.27",
     "@types/react-cytoscapejs": "^1.2.2",
     "@types/react-dom": "18.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,10 +1726,19 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.196.tgz#a7c3d6fc52d8d71328b764e28e080b4169ec7a95"
   integrity sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==
 
-"@types/node@*", "@types/node@18.11.18":
-  version "18.11.18"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz"
-  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+"@types/node@*":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
+
+"@types/node@^20.14.8":
+  version "20.16.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.11.tgz#9b544c3e716b1577ac12e70f9145193f32750b33"
+  integrity sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -6967,6 +6976,11 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 unixify@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
resolves #79 

What I did:
* use `builder-jammy-base` instead of `builder-jammy-full`
* switch to node v20 (LTS) because it was used anyway (prior buildpack Github Action runs did use v20 LTS automatically, because not specified in package.json)

### Technical details and testing

* testing packaging docker containers was done with: `pack build --env NODE_ENV=production ${IMAGE_URI}:latest --builder ${BUILDER} --buildpack ${BUILDPACK} --sbom-output-dir ${BUILDPACK_SBOM_OUTPUT_DIR}`
* before each run, the sbom folder needs to be removed (else it will get bigger and bigger) with the command: `rm -rf sbom-output-dir && `
* Using the paketobuildpacks/builder-jammy-full did result in 1.69GB, see Image 1
* Using the paketobuildpacks/builder-jammy-base did result in 1.07GB, see image 2
* Test was done via `docker run -p:3000:3000 ghcr.io/guacsec/guac-visualizer:latest` and another `guacone` instance running locally on port 8080. The test data was loaded in the browser and there were no errors/warnings in the browser console, nor docker container logs. I was able to browse and navigate through the graph/diagram.

### Image 1

image information when using builder-jammy-full
(used Docker v4.34.3 on OSX, Apple Silicon)
![guac-visualizer_pack_full](https://github.com/user-attachments/assets/04f7e0bd-a258-4b94-b529-112d12b3601c)

### Image 2

image information when using builder-jammy-base
(used Docker v4.34.3 on OSX, Apple Silicon)
![guac-visualizer_pack_base](https://github.com/user-attachments/assets/b479e205-6d6e-4095-97e7-130b130924b5)

### Notes

Cite from https://paketo.io/docs/howto/nodejs/:
*NOTE: Though the example above uses the Paketo Base builder, this buildpack is also compatible with the Paketo Full builder. The Paketo Full builder is required if your app utilizes common C libraries.*
--> since this tool does not make use of common c libs, it's absolutely safe to use the smaller base package.

PS: After reading through the Next.JS docs, I believe the container image size can be further shrinked below 500MB by using plain node.js-slim images, but this requires moving away from buildpacks, as they are not flexible enough for this approach. Are you interested in such a PR?

PPS: Would appreciate a `hacktoberfest-accepted` as well label, if you're fine :)