### PR TITLE
[Feature request] Display version of guac-visualizer and backend GUAC

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,4 +1,17 @@
+'use client';
+
+import {useEffect, useState} from "react";
+
 export default function Footer() {
+  const [versionData, setData] = useState({guacgql: "", guacVisualizer: ""})
+  useEffect(() => {
+    fetch('/api/version')
+      .then((res) => res.json())
+      .then((data) => {
+        setData(data);
+      })
+  }, []);
+
   return (
     <>
       <div className="flex justify-center bg-stone-200 dark:bg-stone-800 px-2 md:px-20 items-center backdrop-blur-sm w-full py-4">
@@ -12,6 +25,10 @@ export default function Footer() {
             Send feedback here!
           </a>
         </h1>
+      </div>
+      <div
+        className="flex justify-center bg-stone-200 dark:bg-stone-800 px-2 md:px-20 items-center backdrop-blur-sm w-full py-1">
+        <small className="text-gray-400">Served by GUAC GraphQL {versionData.guacgql}</small>
       </div>
     </>
   );

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "node": "20.*.*"
   },
   "name": "guac-visualizer",
-  "version": "main",
+  "version": "0.0.0-development",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -1,42 +1,36 @@
 import type {NextApiRequest, NextApiResponse} from 'next'
 import got from 'got'
 import * as console from "node:console";
-import {GUACGQL_SERVER_URL} from "@/src/config";
+import {GUACGQL_SERVER_QUERY_URL} from "@/src/config";
+import packageJson from "@/package.json";
 
 export const config = {
-    api: {
-        // Enable `externalResolver` option in Next.js
-        externalResolver: true,
-        bodyParser: false,
-    },
+  api: {
+    // Enable `externalResolver` option in Next.js
+    externalResolver: true,
+    bodyParser: false,
+  },
 }
 
 export default async function requestGuacGraphql(req: NextApiRequest, res: NextApiResponse) {
-    const options = {
-        body: req.read(),
-        timeout: {
-            connect: 5 // assuming the backend should be able to establish connection in 5 seconds
-        },
-        responseType: "buffer",
-        headers: {
-            "User-Agent": "guac-visualizer", // TODO: add version
-            "Accept": "application/json",
-            "Content-Type": "application/json"
-        }
-    };
-    try {
-        const guacgqlResponse = await got.post(GUACGQL_SERVER_URL, options);
-        return res.status(guacgqlResponse.statusCode).send(guacgqlResponse.body);
-    } catch (error) {
-        console.log("guacgql server error: " + error + ", code: " + error.code);
-        let responseBody = "internal server error";
-        if (error.name == "HTTPError") {
-            responseBody = error.response.body;
-            console.log("gguacgql server response, " +
-                "code: " + error.response.statusCode + ", " +
-                "message: " + responseBody);
-        }
-        return res.status(500).send(responseBody);
+  const options = {
+    body: req.read(),
+    timeout: {
+      connect: 5 // assuming the backend should be able to establish connection in 5 seconds
+    },
+    responseType: "buffer",
+    headers: {
+      "User-Agent": "guac-visualizer-v" + packageJson.version,
+      "Accept": "application/json",
+      "Content-Type": "application/json"
     }
+  };
+  try {
+    const guacgqlResponse = await got.post(GUACGQL_SERVER_QUERY_URL, options);
+    return res.status(guacgqlResponse.statusCode).send(guacgqlResponse.body);
+  } catch (error) {
+    console.log("requestGuacGraphql() -> guacgql server error: " + error + ", url: " + GUACGQL_SERVER_QUERY_URL + ", code: " + error.code + ", message:" + error.response?.body);
+    return res.status(500).send(error.name == "HTTPError" ? error.response.body : "internal server error");
+  }
 }
 

--- a/pages/api/version.ts
+++ b/pages/api/version.ts
@@ -1,0 +1,39 @@
+import type {NextApiRequest, NextApiResponse} from 'next'
+import got from 'got'
+import * as console from "node:console";
+import {GUACGQL_SERVER_VERSION_URL} from "@/src/config";
+import packageJson from "@/package.json";
+
+export const config = {
+  api: {
+    // Enable `externalResolver` option in Next.js
+    externalResolver: true,
+    bodyParser: false,
+  },
+}
+
+export default async function provideVersionInformation(req: NextApiRequest, res: NextApiResponse) {
+  const options = {
+    timeout: {
+      connect: 5 // assuming the backend should be able to establish connection in 5 seconds
+    },
+    responseType: "buffer",
+    headers: {
+      "User-Agent": "guac-visualizer-v" + packageJson.version,
+      "Accept": "application/json",
+    }
+  };
+  let guacgqlVersion: string = "n/a"
+  let guacVisualizerVersion: string = "n/a";
+  try {
+    const guacgqlResponse = await got.get(GUACGQL_SERVER_VERSION_URL, options);
+    guacgqlVersion = guacgqlResponse.body.toString();
+  } catch (error) {
+    console.log("provideVersionInformation() -> guacgql server error: " + error + ", url: " + GUACGQL_SERVER_VERSION_URL + ", code: " + error.code + ", message:" + error.response?.body);
+  }
+  return res.status(200).json({
+    "guacVisualizer": guacVisualizerVersion,
+    "guacgql": guacgqlVersion,
+  });
+}
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,15 @@
 import console from "node:console";
 
 function getGuacQlServerUrl() {
-    let url = process.env.GUACGQL_SERVER_URL;
-    url = url.trim();
-    while (url.length > 0 && url.endsWith("/")) {
-        url = url.substring(0, url.length - 1);
-    }
-    url += "/query";
-    console.log("Using GUACGQL_SERVER_URL=" + url);
-    return new URL(url);
+  let url = process.env.GUACGQL_SERVER_URL;
+  url = url.trim();
+  while (url.length > 0 && url.endsWith("/")) {
+    url = url.substring(0, url.length - 1);
+  }
+  console.log("Using GUACGQL_SERVER_URL=" + url);
+  return url;
 }
 
-export const GUACGQL_SERVER_URL = getGuacQlServerUrl();
+const GUACGQL_SERVER_URL = getGuacQlServerUrl();
+export const GUACGQL_SERVER_QUERY_URL = new URL(GUACGQL_SERVER_URL + "/query");
+export const GUACGQL_SERVER_VERSION_URL = new URL(GUACGQL_SERVER_URL + "/version");


### PR DESCRIPTION
resolves #62 

Changes:
* display guacgql server version in the footer, as well as visualizer version in the header.
* simplify logging code for backend calls
* send version information to guacgql backend

This is, how it looks like (look in the header, and footer)
![Screenshot 2024-10-25 at 11 09 24](https://github.com/user-attachments/assets/91e07ce2-a63d-45be-a9ed-ba7b48643e26)


Hint:
The visualizer's version number is pulled from the package.json, which means when a release is made, this must be changed as well. In the Github Action, this is already implemented, see release.yaml the step named `Update version string to match git tag`