### PR TITLE
Add id-token permission to build-n-release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
       BUILDPACK_SPDX_SBOM: "launch/paketo-buildpacks_yarn-install/launch-modules/sbom.spdx.json"
     permissions:
       packages: write # To publish container images to GHCR
+      id-toke: write # For sigstore to use our OIDC token for signing
     steps:
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag=v3


### PR DESCRIPTION
sigstore needs the id-token access, otherwise it tries to use a browser code to authenticate, per
https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings

Arguably, we should split this out into several jobs, but that doesn't seem worth the effort.