### PR TITLE
fix: open external links in new tab

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
           <a
             className="text-purple-900 font-semibold"
             href="https://forms.gle/Bv1RgaPvuxXdJPt17"
-            target="blank"
+            target="_blank"
           >
             Send feedback here!
           </a>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -17,20 +17,21 @@ export default function Header() {
         <a
           className="block py-1 text-sm text-gray-800 dark:text-stone-300 hover:bg-white dark:hover:bg-black rounded-xl p-3 my-2"
           href="https://github.com/guacsec/guac-visualizer"
-          target="blank"
+          target="_blank"
         >
           GitHub
         </a>
         <a
           className="block py-1 text-sm text-gray-800 dark:text-stone-300 hover:bg-white dark:hover:bg-black rounded-xl p-3 my-2"
           href="https://docs.guac.sh/"
-          target="blank"
+          target="_blank"
         >
           GUAC Docs
         </a>
         <a
           className="block py-1 text-sm text-gray-800 dark:text-stone-300 hover:bg-white dark:hover:bg-black rounded-xl p-3 my-2"
           href="https://guac.sh/community/"
+          target="_blank"
         >
           Community
         </a>


### PR DESCRIPTION
Change `target="blank"` to `target="_blank"` for the external links.

Fixes #185